### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/phew.gemspec
+++ b/phew.gemspec
@@ -24,15 +24,16 @@ Gem::Specification.new do |spec|
 
   spec.rdoc_options = ["--main", "README.md"]
 
-  spec.add_runtime_dependency("gir_ffi-gtk", "~> 0.16.0")
-  spec.add_runtime_dependency("gir_ffi-pango", "0.0.16")
+  spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.16.0"
+  spec.add_runtime_dependency "gir_ffi-pango", "0.0.16"
 
-  spec.add_development_dependency("atspi_app_driver", "~> 0.8.0")
-  spec.add_development_dependency("minitest", ["~> 5.12"])
-  spec.add_development_dependency("pry", "~> 0.14.0")
-  spec.add_development_dependency("rake", ["~> 13.0"])
-  spec.add_development_dependency("rake-manifest", "~> 0.2.0")
-  spec.add_development_dependency("rubocop", "~> 1.25")
-  spec.add_development_dependency("rubocop-minitest", "~> 0.31.0")
-  spec.add_development_dependency("rubocop-performance", "~> 1.13")
+  spec.add_development_dependency "atspi_app_driver", "~> 0.8.0"
+  spec.add_development_dependency "minitest", "~> 5.12"
+  spec.add_development_dependency "pry", "~> 0.14.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
+  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
+  spec.add_development_dependency "rubocop-performance", "~> 1.18"
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
