### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/phew.gemspec
+++ b/phew.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.rdoc_options = ["--main", "README.md"]
 
-  spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
-  spec.add_runtime_dependency "gir_ffi-pango", "0.0.17"
+  spec.add_dependency "gir_ffi-gtk", "~> 0.17.0"
+  spec.add_dependency "gir_ffi-pango", "0.0.17"
 
   spec.add_development_dependency "atspi_app_driver", "~> 0.9.0"
   spec.add_development_dependency "minitest", "~> 5.12"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
