### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/phew.gemspec
+++ b/phew.gemspec
@@ -11,10 +11,11 @@ Gem::Specification.new do |spec|
   spec.summary = "A GNOME Font Viewer"
   spec.description = "List and compare installed fonts on GNOME"
   spec.homepage = "http://www.github.com/mvz/phew-font-viewer"
+
   spec.license = "GPL-3"
+  spec.required_ruby_version = ">= 3.1.0"
 
-  spec.required_ruby_version = ">= 3.0.0"
-
+  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = File.read("Manifest.txt").split


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
