### PR TITLE
Remove unused gir1.2-webkit2-4.0 dependency from GitHub Actions setup

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,8 +36,6 @@ jobs:
           sudo apt-get install gir1.2-atspi-2.0
           # Provides A11y services used by atspi_app_driver to drive SUT
           sudo apt-get install at-spi2-core
-          # GIR data for GtkWebkit 4
-          sudo apt-get install gir1.2-webkit2-4.0 --no-install-recommends
           # Provides xvfb-run
           sudo apt-get install xvfb
 


### PR DESCRIPTION
Webkit is not used by Phew.
