### PR TITLE
Limit set of apt dependencies installed in GitHub Actions test job

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,14 +30,14 @@ jobs:
           sudo apt-get update
           # Provides libgirepository-1.0.so.1
           sudo apt-get install libgirepository-1.0-1
+          # Provides Gtk-3.0.typelib
+          sudo apt-get install gir1.2-gtk-3.0
           # BUG: Missing dependency of gir1.2-harfbuzz-0.0
           sudo apt-get install libharfbuzz-gobject0
           # Provides Atspi-2.0.typelib
           sudo apt-get install gir1.2-atspi-2.0
           # Provides A11y services used by atspi_app_driver to drive SUT
           sudo apt-get install at-spi2-core
-          # GIR data for GtkWebkit 4
-          sudo apt-get install gir1.2-webkit2-4.0 --no-install-recommends
           # Provides xvfb-run
           sudo apt-get install xvfb
 


### PR DESCRIPTION
Webkit is not used by Phew, so gir1.2-webkit2-4.0 can be removed. Since that package pulled in gir1.2-gtk-3.0, we now need to install the latter directly.
