### PR TITLE
Switch GitHub Actions back to ubuntu latest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ name: CI
 jobs:
   test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/phew.gemspec
+++ b/phew.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gir_ffi-gtk", "~> 0.18.0"
   spec.add_dependency "gir_ffi-pango", "0.0.18"
 
-  spec.add_development_dependency "atspi_app_driver", "~> 0.10.0"
+  spec.add_development_dependency "atspi_app_driver", "~> 0.10.1"
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"


### PR DESCRIPTION
Since gir1.2-webkit2-4.0 is no longer being installed, that dependency issue has been resolved.

Also, because phew-font-viewer now depends on `gir_ffi` 0.18.0, running on ubuntu-latest (24.04) has become possible without installing gobject dev packages.
