### PR TITLE
Update RuboCop configuration and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-minitest
 

--- a/features/basic_run_test.rb
+++ b/features/basic_run_test.rb
@@ -22,6 +22,7 @@ describe "The Phew application" do
     frame.find_role(:menu_item, /Quit/).do_action 0
 
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 
@@ -31,14 +32,17 @@ describe "The Phew application" do
     box = frame.find_role :combo_box
 
     latin = box.find_role :menu_item, /latin/
+
     _(latin).wont_be_nil
 
     textbox = frame.find_role :text
+
     _(textbox).wont_be_nil
     _(textbox.get_text(0, 100)).must_equal ""
 
     _(box.get_action_name(0)).must_equal "press"
     box.do_action 0
+
     _(latin.get_action_name(0)).must_equal "click"
     latin.do_action 0
 
@@ -46,6 +50,7 @@ describe "The Phew application" do
 
     frame.find_role(:menu_item, /Quit/).do_action 0
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 

--- a/phew.gemspec
+++ b/phew.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
 end

--- a/test/phew/font_repository_test.rb
+++ b/test/phew/font_repository_test.rb
@@ -8,6 +8,7 @@ describe Phew::FontRepository do
       ctx = Gdk.pango_context_get
       repo = Phew::FontRepository.new ctx
       font = repo.get_font "Sans"
+
       _(font).must_be_instance_of Phew::Font
     end
 
@@ -16,6 +17,7 @@ describe Phew::FontRepository do
       repo = Phew::FontRepository.new ctx
       font = repo.get_font "Sans"
       font_again = repo.get_font "Sans"
+
       _(font_again).must_be_same_as font
     end
   end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
